### PR TITLE
Don't show recently used apps in the Dock

### DIFF
--- a/macos/defaults.sh
+++ b/macos/defaults.sh
@@ -245,6 +245,9 @@ defaults write com.apple.dock wvous-tr-corner -int 0
 defaults write com.apple.dock wvous-bl-corner -int 0
 defaults write com.apple.dock wvous-br-corner -int 0
 
+# Don't show recently used applications in the Dock
+defaults write com.Apple.Dock show-recents -bool false
+
 ###############################################################################
 # Mail                                                                        #
 ###############################################################################


### PR DESCRIPTION
In macOS Mojave, Apple looks to have introduced [this](https://www.macworld.com/article/3284519/os-x/article.html), where recently closed apps will appear in a special section of the Dock. It's kinda lame IMO, so if you want to disable it, this is how :).