### PR TITLE
当操作系统为 macos 时，添加 brew 中的 ruby 到当前 path 环境变量中。

### DIFF
--- a/system/.path.macos
+++ b/system/.path.macos
@@ -1,0 +1,17 @@
+# Start with system path
+# Retrieve it from getconf, otherwise it's just current $PATH
+
+is-executable getconf && PATH=$($(command -v getconf) PATH)
+
+# Prepend new items to path (if directory exists)
+
+prepend-path "/usr/local/opt/ruby/bin"
+
+# Remove duplicates (preserving prepended items)
+# Source: http://unix.stackexchange.com/a/40755
+
+PATH=$(echo -n $PATH | awk -v RS=: '{ if (!arr[$0]++) {printf("%s%s",!ln++?"":":",$0)}}')
+
+# Wrap up
+
+export PATH


### PR DESCRIPTION
https://github.com/Homebrew/homebrew-core/commit/b4bf45228a60a9a64a0f17d0374b27ffe84c862c

这次提交导致 brew 当中的 ruby 并不会产生可执行文件在 /usr/local/bin 当中，而是产生在 /usr/local/opt/ruby/bin 当中，又由于该脚本只在操作系统为 macos 时，才会使用 brew install ruby 。所以添加 system/.path.macos 文件来解决当 make 时，错误的使用系统自带的 gem 程序，最终导致 make 失败。
具体错误如下：
gem install awesome_bot pygmentize
ERROR:  While executing gem ... (Gem::FilePermissionError)
    You don't have write permissions for the /Library/Ruby/Gems/2.3.0 directory.
make: *** [gems] Error 1
