### PR TITLE
在 make bash 时，错误的使用了非系统指令导致的报错

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ brew:
 bash: BASH=/usr/local/bin/bash
 bash: SHELLS=/private/etc/shells
 bash: brew
-	if ! grep -q $(BASH) $(SHELLS); then brew install bash bash-completion@2 && sudo append $(BASH) $(SHELLS) && chsh -s $(BASH); fi
+	if ! grep -q $(BASH) $(SHELLS); then brew install bash bash-completion@2 pcre && sudo append $(BASH) $(SHELLS) && chsh -s $(BASH); fi
 
 git: brew
 	brew install git git-extras


### PR DESCRIPTION
具体错误为：
/Users/undancer/.dotfiles//bin/append:行6: pcregrep: 未找到命令