### PR TITLE
brew 4 updates

### DIFF
--- a/install/Brewfile
+++ b/install/Brewfile
@@ -1,5 +1,4 @@
 tap "homebrew/bundle"
-tap "homebrew/core"
 tap "lotyp/homebrew-formulae"
 
 # core/dotfiles

--- a/install/Caskfile
+++ b/install/Caskfile
@@ -1,4 +1,3 @@
-tap "homebrew/cask"
 tap "homebrew/cask-drivers"
 tap "homebrew/cask-fonts"
 tap "homebrew/cask-versions"


### PR DESCRIPTION
As of Brew 4, the [default behavior is to download JSON files](https://brew.sh/2023/02/16/homebrew-4.0.0/) via the API for core/cask taps, so tapping core/cask manually is no longer required and in fact wastes time/space.

BTW thanks for sharing your dotfiles, they are super helpful!