### PR TITLE
Fix #34: brew: no such file or directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
-SHELL = /bin/bash
 DOTFILES_DIR := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 OS := $(shell bin/is-supported bin/is-macos macos linux)
 HOMEBREW_PREFIX := $(shell bin/is-supported bin/is-macos $(shell bin/is-supported bin/is-arm64 /opt/homebrew /usr/local) /home/linuxbrew/.linuxbrew)
 export N_PREFIX = $(HOME)/.n
 PATH := $(HOMEBREW_PREFIX)/bin:$(DOTFILES_DIR)/bin:$(N_PREFIX)/bin:$(PATH)
+SHELL := env PATH=$(PATH) /bin/bash
 SHELLS := /private/etc/shells
 BIN := $(HOMEBREW_PREFIX)/bin
 export XDG_CONFIG_HOME = $(HOME)/.config


### PR DESCRIPTION
This fixes #34, though I can't say I fully understand why it's necessary. I would expect any global variable (including PATH) to be inherited by shells, and even without this `which brew` correctly returns `/opt/homebrew/bin`. It just can't run the command for whatever reason.

But I'm not sure I have time to debug this any further, and this seems like a better solution than prefixing every command with `$(BIN)`.

Shamelessly stolen from https://stackoverflow.com/questions/8941110/how-i-could-add-dir-to-path-in-makefile