### PR TITLE
Quote bash vars

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,15 +42,15 @@ packages: brew-packages cask-apps node-packages rust-packages
 link: stow-$(OS)
 	for FILE in $$(\ls -A runcom); do if [ -f $(HOME)/$$FILE -a ! -h $(HOME)/$$FILE ]; then \
 		mv -v $(HOME)/$$FILE{,.bak}; fi; done
-	mkdir -p $(XDG_CONFIG_HOME)
-	stow -t $(HOME) runcom
-	stow -t $(XDG_CONFIG_HOME) config
+	mkdir -p "$(XDG_CONFIG_HOME)"
+	stow -t "$(HOME)" runcom
+	stow -t "$(XDG_CONFIG_HOME)" config
 	mkdir -p $(HOME)/.local/runtime
 	chmod 700 $(HOME)/.local/runtime
 
 unlink: stow-$(OS)
-	stow --delete -t $(HOME) runcom
-	stow --delete -t $(XDG_CONFIG_HOME) config
+	stow --delete -t "$(HOME)" runcom
+	stow --delete -t "$(XDG_CONFIG_HOME)" config
 	for FILE in $$(\ls -A runcom); do if [ -f $(HOME)/$$FILE.bak ]; then \
 		mv -v $(HOME)/$$FILE.bak $(HOME)/$${FILE%%.bak}; fi; done
 


### PR DESCRIPTION
If your XDG_CONFIG_HOME has spaces in it (for instance, on MacOS I think it should be `/Users/dane.powell/Library/Application Support`), bad things happen when config gets stowed. There are probably other places where quotes need to be used as well, I haven't checked beyond the stow operations.